### PR TITLE
Upgraded library versions

### DIFF
--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -52,9 +52,9 @@ dependencies {
     //compile fileTree(include: ['*.jar'], dir: 'libs')
 
     // Uncomment the following for jCenter or Maven distribution
-    final RETROFIT_VERSION = '2.0.0-beta4'
-    final OKHTTP_VERSION = '3.1.2'
-    final RXJAVA_VERSION = '1.1.1'
+    final RETROFIT_VERSION = '2.0.2'
+    final OKHTTP_VERSION = '3.3.1'
+    final RXJAVA_VERSION = '1.1.5'
 
     // Http networking
     compile "com.squareup.retrofit2:retrofit:$RETROFIT_VERSION"


### PR DESCRIPTION
This is in response to a crash case reported by The Economist in relation to OkHttp. All library versions are updated to the latest to incorporate any fixes.

A crash log of The Economist's test app shows that the crash actually happens in the SDK code of another vendor called TwinPrime, logs attached.

[crash.txt](https://github.com/chartbeat-labs/android_sdk/files/301299/crash.txt)