### PR TITLE
Fixed crash when restarting ChartbeatService

### DIFF
--- a/sdk/src/main/java/com/chartbeat/androidsdk/ChartbeatService.java
+++ b/sdk/src/main/java/com/chartbeat/androidsdk/ChartbeatService.java
@@ -21,8 +21,8 @@ public class ChartbeatService extends Service {
     private static final String TAG = ChartbeatService.class.getSimpleName();
     private static final String TRACKER_THREAD = "TRACKER_THREAD";
 
-    private static HandlerThread bgThread;
-    private static ChartbeatServiceHandler handler;
+    private HandlerThread bgThread;
+    private ChartbeatServiceHandler handler;
 
     @Override
     public IBinder onBind(Intent intent) {
@@ -57,5 +57,6 @@ public class ChartbeatService extends Service {
     public void onDestroy() {
         handler.removeCallbacksAndMessages(null);
         bgThread.quit();
+        bgThread = null;
     }
 }


### PR DESCRIPTION
We are seeing a crash
```
Attempt to read from field 'android.os.MessageQueue android.os.Looper.mQueue' on a null object reference
  at android.os.Handler.<init>(Handler.java:229)
  at android.os.Handler.<init>(Handler.java:137)
  at com.chartbeat.androidsdk.ChartbeatServiceHandler.<init>(Unknown Source)
  at com.chartbeat.androidsdk.ChartbeatService.onCreate(Unknown Source)
```
which seems to be cause by `onDestroy()` followed by `onCreate()` being called on the service without the process dying. This mean `bgThread` is not recreated and `getLooper()` is null. By making the fields non-static and nulling out `bgThread` it ensures the thread is properly created again in `onCreate()`.