### PR TITLE
fix background crash

### DIFF
--- a/sdk/src/main/java/com/chartbeat/androidsdk/ChartbeatService.java
+++ b/sdk/src/main/java/com/chartbeat/androidsdk/ChartbeatService.java
@@ -59,10 +59,16 @@ public class ChartbeatService extends Service {
         handler.removeCallbacksAndMessages(null);
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR2) {
-            bgThread.getLooper().quitSafely();
+            if (bgThread.getLooper() != null) {
+                bgThread.getLooper().quitSafely();
+            }
+
             bgThread.quitSafely();
         } else {
-            bgThread.getLooper().quit();
+            if (bgThread.getLooper() != null) {
+                bgThread.getLooper().quit();
+            }
+
             bgThread.quit();
         }
 

--- a/sdk/src/main/java/com/chartbeat/androidsdk/ChartbeatService.java
+++ b/sdk/src/main/java/com/chartbeat/androidsdk/ChartbeatService.java
@@ -7,6 +7,7 @@ package com.chartbeat.androidsdk;
 import android.app.Service;
 import android.content.Context;
 import android.content.Intent;
+import android.os.Build;
 import android.os.HandlerThread;
 import android.os.IBinder;
 import android.os.Message;
@@ -31,7 +32,7 @@ public class ChartbeatService extends Service {
 
     @Override
     public void onCreate() {
-        if (bgThread == null) {
+        if (bgThread == null || !bgThread.isAlive()) {
             bgThread = new HandlerThread(TRACKER_THREAD, Process.THREAD_PRIORITY_BACKGROUND);
             bgThread.start();
         }
@@ -56,6 +57,15 @@ public class ChartbeatService extends Service {
     @Override
     public void onDestroy() {
         handler.removeCallbacksAndMessages(null);
-        bgThread.quit();
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR2) {
+            bgThread.getLooper().quitSafely();
+            bgThread.quitSafely();
+        } else {
+            bgThread.getLooper().quit();
+            bgThread.quit();
+        }
+
+        bgThread = null;
     }
 }


### PR DESCRIPTION
This PR fixes a background crash that happens on some Android OS versions.

Explanation: `ChartbeatService` is part of the client application process and can be killed along with the application, however under certain scenarios (newer Android OS versions) the service itself can be killed independently. 

Due to the `START_STICKY` flag the service will be restarted with the `HandlerThread`'s `Looper` still uninitialized. This PR properly quits the `Looper` and the `HandlerThread` and performs additional checks to ensure they are re-initialized correctly