### PR TITLE
add timer window based user interaction tracking

### DIFF
--- a/sdk/src/main/java/com/chartbeat/androidsdk/Tracker.java
+++ b/sdk/src/main/java/com/chartbeat/androidsdk/Tracker.java
@@ -88,7 +88,7 @@ public final class Tracker {
     static final String KEY_DOC_WIDTH = "KEY_DOC_WIDTH";
 
     private static Subscription userInteractSubscription;
-    private static final int USER_INTERACT_WINDOW_IN_SECONDS = 5;
+    private static final int USER_INTERACT_WINDOW_IN_MILLISECONDS = 500;
 
     /** ----------- Public static functions -------------- */
 
@@ -311,7 +311,7 @@ public final class Tracker {
         intent.putExtra(KEY_SDK_ACTION_TYPE, ACTION_USER_INTERACTED);
         appContext.startService(intent);
 
-        userInteractSubscription = Observable.timer(USER_INTERACT_WINDOW_IN_SECONDS, TimeUnit.SECONDS)
+        userInteractSubscription = Observable.timer(USER_INTERACT_WINDOW_IN_MILLISECONDS, TimeUnit.MILLISECONDS)
                 .observeOn(Schedulers.io())
                 .subscribe(new Subscriber<Long>() {
                     @Override


### PR DESCRIPTION
This is a workaround for a potential issue that may happen on some devices.

- `onUserInteraction` from the `Activity` or `AppCompatActivity` classes in the Android framework can be called frequently (upon every user interaction). Since we rely on passing this signal to Chartbeat's background service, the amount of time it takes to process the signal could result in ANR issues.
- As a work around, I have added a 5 second (can be adjusted) timer to ensure that user interaction tracking only happens at most once every 5 seconds (this still fall in the pinger window) and prevent unnecessary processing in the background service.
- Upon user visiting a new view or leaving an old view, the timer is reset to prevent memory leaks/issues.
