### PR TITLE
updated readme with stopTracker() information

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,9 @@ do this in each one.
 the foreground, you should also call `userLeftView()`, which can be done from your
 activity's `onPause()` function. If your app has multiple activities, be sure to
 do this in each one.
+* When a user closes the app, use `stopTracker()` to destroy the Tracker object. This will remove
+any retained values in the Tracker such as path, title and engaged time. The Tracker will have to
+be re-initialized using `setupTracker()`, which should occur on app re-entry.
 * You will usually want to call `userInteracted()` from your activity's
 `onUserInteraction()` function,
 as well, and any time the user types, you will want to call `userTyped()`. If your app


### PR DESCRIPTION
Hey team, just a simple update to the docs as per request by CNN. I did some testing on stopTracker() and it completely destroys/nullifies all properties of the Tracker. After stopTracker() is called, the ChartbeatService spits out log statements complaining that the Tracker has not been initialized. Seems safe to say that it just destroys the Tracker, but the ChartbeatService still runs.

Please let me know if there are any objections to this update or if you'd like any more info on my findings. For now, it seems good to update this readme in prep for the move of the docs to the support site or wherever. 