### PR TITLE
handle 202 status codes from memoryfly

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,7 @@
 buildscript {
     repositories {
         jcenter()
+        google()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:3.0.1'

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.2'
+        classpath 'com.android.tools.build:gradle:3.0.1'
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.7.3'
         classpath 'com.github.dcendents:android-maven-gradle-plugin:1.4.1'
     }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Thu Apr 06 16:40:58 EDT 2017
+#Fri Feb 09 16:49:35 EST 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -5,12 +5,11 @@ version = '1.3.5'
 
 android {
     compileSdkVersion 26
-    buildToolsVersion "26.0.1"
 
     defaultConfig {
         minSdkVersion 14
         targetSdkVersion 26
-        versionCode 6
+        versionCode 100
         versionName "2.0"
     }
 

--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'com.android.library'
 
 group = 'com.chartbeat.sdk'
-version = '1.3.5'
+version = '1.3.6'
 
 android {
     compileSdkVersion 26
@@ -36,7 +36,7 @@ ext {
     siteUrl = 'https://github.com/chartbeat-labs/android_sdk'
     gitUrl = 'https://github.com/dcendents/android-maven-gradle-plugin.git'
 
-    libraryVersion = '1.3.5'
+    libraryVersion = '1.3.6'
 
     developerId = 'rmangi'
     developerName = 'Rick Mangi'

--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -9,7 +9,7 @@ android {
     defaultConfig {
         minSdkVersion 14
         targetSdkVersion 26
-        versionCode 100
+        versionCode 7
         versionName "2.0"
     }
 

--- a/sdk/src/main/java/com/chartbeat/androidsdk/AppInfo.java
+++ b/sdk/src/main/java/com/chartbeat/androidsdk/AppInfo.java
@@ -8,7 +8,7 @@ import android.graphics.Point;
  */
 final class AppInfo {
     private static final String TAG = AppInfo.class.getSimpleName();
-    private static final String SDK_NAME = "android";
+    private static final int ANDROID_SDK_VERSION_BASE = 2000;
 
     private static String packageName;
     private static String referrer;
@@ -65,7 +65,7 @@ final class AppInfo {
     }
 
     String getSdkVersion() {
-        return String.valueOf(BuildConfig.VERSION_CODE);
+        return String.valueOf(ANDROID_SDK_VERSION_BASE + BuildConfig.VERSION_CODE);
     }
 
     String getDeviceScreenWidth() {

--- a/sdk/src/main/java/com/chartbeat/androidsdk/AppInfo.java
+++ b/sdk/src/main/java/com/chartbeat/androidsdk/AppInfo.java
@@ -65,7 +65,7 @@ final class AppInfo {
     }
 
     String getSdkVersion() {
-        return SDK_NAME + "_" + BuildConfig.VERSION_CODE;
+        return String.valueOf(BuildConfig.VERSION_CODE);
     }
 
     String getDeviceScreenWidth() {

--- a/sdk/src/main/java/com/chartbeat/androidsdk/ChartBeatTracker.java
+++ b/sdk/src/main/java/com/chartbeat/androidsdk/ChartBeatTracker.java
@@ -22,6 +22,8 @@ final class ChartBeatTracker {
 
     private static final long MILLISECONDS_IN_ONE_SECOND = 1000;
 
+    private static final int PING_ENDPOINT_VERSION = 1;
+
     private static Handler handler;
     private static boolean firstPing = true;
 
@@ -268,6 +270,11 @@ final class ChartBeatTracker {
             parameters.put(QueryKeys.TIME_ZONE, String.valueOf(timezoneOffset));
 
             addParameterIfRequired(parameters, QueryKeys.SCREEN_WIDTH, appInfo.getDeviceScreenWidth());
+
+            // The tell memoryfly which interaction or API version is expected.
+            // Setting <MEMFLY_API_VERSION> to 1 indicates that 202 status codes are
+            // expected rather than 500 when referrer is not present in the ping.
+            addParameterIfRequired(parameters, QueryKeys.MEMFLY_API_VERSION, String.valueOf(PING_ENDPOINT_VERSION));
 
 //            if (locationService != null) {
 //                addParameterIfRequired(parameters, QueryKeys.LONGITUDE, locationService.getLongitude());

--- a/sdk/src/main/java/com/chartbeat/androidsdk/ChartBeatTracker.java
+++ b/sdk/src/main/java/com/chartbeat/androidsdk/ChartBeatTracker.java
@@ -36,7 +36,7 @@ final class ChartBeatTracker {
     private ViewTracker currentViewTracker;
 
     private PingParams pingParams;
-    
+
 	/** set to true to simulate a very long response to pings (10 seconds) */
 	public static final boolean SIMULATE_VERY_SLOW_SERVER = false;
 
@@ -66,12 +66,12 @@ final class ChartBeatTracker {
 
         Logger.d(TAG, appInfo.toString());
 	}
-    
+
     synchronized void stopTracker() {
         pingManager.stop();
         engagementTracker.stop();
     }
-    
+
     synchronized void setExternalReferrer(String appReferrer) {
         appInfo.setExternalReferrer(appReferrer);
     }
@@ -348,7 +348,7 @@ final class ChartBeatTracker {
                     pingManager.suspendDueToServerBusy();
                 }
                 pingManager.setInBackground(isInBackground);
-                if (code == 500 || code == 400) {
+                if (code == 500 || code == 400 || code == 202) {
                     engagementTracker.lastPingFailed(engagementSnapshot);
                     pingManager.retryImmediately();
                 }

--- a/sdk/src/main/java/com/chartbeat/androidsdk/QueryKeys.java
+++ b/sdk/src/main/java/com/chartbeat/androidsdk/QueryKeys.java
@@ -70,5 +70,7 @@ final class QueryKeys {
     public static final String SCREEN_WIDTH = "S";
     public static final String PAGE_LOAD_TIME = "b";
 
+    public static final String MEMFLY_API_VERSION = "Z";
+
     public static final String END_MARKER = "_";
 }

--- a/testapp/build.gradle
+++ b/testapp/build.gradle
@@ -2,7 +2,6 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 23
-    buildToolsVersion "23.0.2"
 
     defaultConfig {
         applicationId "com.example.chartbeatsdktest"


### PR DESCRIPTION
#### What does this change do?

This change makes it possible for memoryfly to respond with a status code of 202 rather than 500 in cases where there is not actually a server error but there is an error with the data being sent. Status code 202 indicates that something is wrong with the data but that the SDK should try to resend it.

#### What specific feedback (if any) do you seek from this review?

  - I made some suggested updates to the gradle builds. These were suggested by the most recent version of Android Studio. Do these changes seem ok?
  - This PR changes what is being sent in the `V`-key. Should we reconsider this change?

#### Why are we making this change?
Jira story: https://chartbeat.atlassian.net/browse/CAL-27
Related memorfly PR: https://github.com/chartbeat/chartbeat/pull/6571

#### How should this be tested; or how was it tested?
Only tested with the included sample test app.

#### Who should review this PR?
@heavi5ide @rappoport
